### PR TITLE
[SEC-1] Fix OOB read in Checkpoint LEA multi-colon loop

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3309,7 +3309,7 @@ PARSER_Parse(CheckpointLEA)
 			FAIL(LN_WRONGPARSER);
 		}
 		/* Sometimes there is multiple colons */
-		while( i < npb->strLen && npb->str[i+1] == ':' ) {
+		while( i + 1 < npb->strLen && npb->str[i+1] == ':' ) {
 			i++;
 		}
 		lenName = i - iName;


### PR DESCRIPTION
Fixes #2

Adds a bounds check before the inner `while(npb->str[i+1] == ':')` loop in the Checkpoint LEA parser so it cannot read past the end of the input buffer.