### PR TITLE
[SEC-2] Fix OOB read in Checkpoint LEA quoted-value handler

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3321,7 +3321,7 @@ PARSER_Parse(CheckpointLEA)
 		if( npb->str[i] == '"' ) {
 			iValue = i+1;
 			i++;
-			while( i < npb->strLen && ( npb->str[i] != '"' || npb->str[i-1] == '\\' ) ) {
+			while( i < npb->strLen && ( npb->str[i] != '"' || (i > 0 && npb->str[i-1] == '\\') ) ) {
 				++i;
 			}
 			// Do not take the " in value


### PR DESCRIPTION
Fixes #3

Adds a `i < npb->strLen` guard in the quoted-value scanning loop so the parser cannot read past the buffer end when the closing quote is absent or at the last byte.