### PR TITLE
[SEC-4] Fix OOB read in op-quoted-string escape handler

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1700,7 +1700,7 @@ PARSER_Parse(OpQuotedString)
 			CHKN(cstr = malloc(end - i + 1));
 			int cpt_dst = 0;
 			while(i < end) {
-				if( (npb->str[i] == '\\') && ((npb->str[i+1] == '\\') || (npb->str[i+1] == '"')) ) {
+				if( (i + 1 < end) && (npb->str[i] == '\\') && ((npb->str[i+1] == '\\') || (npb->str[i+1] == '"')) ) {
 					i++;
 				}
 				*(cstr+(cpt_dst++)) = *(npb->str+(i++));


### PR DESCRIPTION
Fixes #5

Guards the escape lookahead in the op-quoted-string parser with an `i + 1 < end` check so a trailing backslash at the buffer boundary does not read past the end.