### PR TITLE
[SEC-5] Fix unsigned integer underflow in strrev() on empty string

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1219,6 +1219,7 @@ done:
 static char *
 strrev(char *const __restrict__ str)
 {
+	if(str == NULL || str[0] == '\0') return str;
 	char ch;
 	size_t i = strlen(str)-1,j=0;
 	while(i>j)


### PR DESCRIPTION
Fixes #6

Adds a NULL/empty guard at the top of `strrev()` in pdag.c to prevent unsigned underflow when the function is called with an empty string, which would cause an infinite loop or memory corruption.