### PR TITLE
[BUG-1] Fix wrong cookie passed to error message callback

### DIFF
--- a/src/lognorm.c
+++ b/src/lognorm.c
@@ -131,7 +131,7 @@ ln_errprintf(const ln_ctx ctx, const int eno, const char *fmt, ...)
 		free((void*) m);
 	}
 
-	ctx->errmsgCB(ctx->dbgCookie, msg, lenBuf);
+	ctx->errmsgCB(ctx->errmsgCookie, msg, lenBuf);
 	ln_dbgprintf(ctx, "%s", msg);
 done:	return;
 }


### PR DESCRIPTION
Fixes #8

`ln_errprintf` was passing `ctx->dbgCookie` instead of `ctx->errmsgCookie` to the error callback, so any application that registers separate debug and error callbacks would receive the wrong user data pointer in its error handler.