### PR TITLE
[BUG-2] Fix double-free guard: LN_ObjID_None was equal to LN_ObjID_CTX

### DIFF
--- a/src/lognorm.h
+++ b/src/lognorm.h
@@ -35,7 +35,7 @@
 #define MAX_FIELDNAME_LEN 1024
 #define MAX_TYPENAME_LEN  1024
 
-#define LN_ObjID_None 0xFEFE0001
+#define LN_ObjID_None 0xFEFE0000 /* must differ from LN_ObjID_CTX to enable double-free guard */
 #define LN_ObjID_CTX 0xFEFE0001
 
 struct ln_type_pdag {


### PR DESCRIPTION
Fixes #9

`LN_ObjID_None` and `LN_ObjID_CTX` were both defined as `0xFEFE0001`, making the double-free guard in `ln_exitCtx` a no-op. Changed `LN_ObjID_None` to `0xFEFE0000`.