### PR TITLE
[BUG-3] Fix ln_fmtEventToRFC5424 and ln_fmtEventToXML always returning -1

### DIFF
--- a/src/enc_syslog.c
+++ b/src/enc_syslog.c
@@ -203,7 +203,7 @@ ln_fmtEventToRFC5424(struct json_object *json, es_str_t **str)
 		json_object_iter_next(&it);
 	}
 	es_addChar(str, ']');
-
+	r = 0;
 done:
 	return r;
 }

--- a/src/enc_xml.c
+++ b/src/enc_xml.c
@@ -224,7 +224,7 @@ ln_fmtEventToXML(struct json_object *json, es_str_t **str)
 	}
 
 	es_addBuf(str, "</event>", 8);
-
+	r = 0;
 done:
 	return r;
 }


### PR DESCRIPTION
Fixes #10

Both formatters initialised `r = -1` and never set `r = 0` on the success path. Added `r = 0;` before the `done:` label in both `enc_syslog.c` and `enc_xml.c`.