### PR TITLE
[BUG-5] Fix corrupted AC_SEARCH_LIBS call in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ m4_ifdef([AX_IS_RELEASE], [
 # Checks for libraries.
 save_LIBS=$LIBS
 LIBS=
-AC_SEARCH_LIBS(clock_getm4_defn([AC_AUTOCONF_VERSION]), [2.68]time, rt)
+AC_SEARCH_LIBS([clock_gettime], [rt])
 LIBS=$save_LIBS
 
 # Checks for header files.


### PR DESCRIPTION
Fixes #12

Line 41 of `configure.ac` had an m4 macro fragment spliced into the middle of `AC_SEARCH_LIBS`, producing a syntactically invalid call that broke the build. Replaced with the correct `AC_SEARCH_LIBS([clock_gettime], [rt])`.