### PR TITLE
[MEM-4] Check strdup(conf_file) return value in addSampToTree

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/src/samp.c
+++ b/src/samp.c
@@ -376,6 +376,7 @@ addSampToTree(ln_ctx ctx,
 	dag->flags.isTerminal = 1;
 	dag->tags = tagBucket;
 	dag->rb_file = strdup(ctx->conf_file);
+	if(dag->rb_file == NULL) { r = LN_NOMEM; goto done; }
 	dag->rb_lineno = ctx->conf_ln_nbr;
 
 done:


### PR DESCRIPTION
Fixes #16

`strdup(ctx->conf_file)` at samp.c:378 could return NULL on allocation failure. The result was stored in `dag->rb_file` without a check, leading to a potential NULL dereference later. Added a NULL check with `LN_NOMEM` error propagation.