### PR TITLE
[ERR-2] Fix getLineType() always returning -1 — rulebase loading was broken

### DIFF
--- a/src/samp.c
+++ b/src/samp.c
@@ -409,6 +409,7 @@ getLineType(const char *buf, es_size_t lenBuf, size_t *offs, es_str_t **str)
 	if(i < lenBuf)
 		++i; /* skip over '=' */
 	*offs = i;
+	r = 0;
 
 done:	return r;
 }

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -427,6 +427,7 @@ getLineType(const char *buf, es_size_t lenBuf, es_size_t *offs, es_str_t **str)
 	if(i < lenBuf)
 		++i; /* skip over '=' */
 	*offs = i;
+	r = 0;
 
 done:	return r;
 }


### PR DESCRIPTION
Fixes #18

`getLineType()` in both `samp.c` and `v1_samp.c` initialised `r = -1` but never set `r = 0` on the success path. This caused every correctly-formatted rule line to be treated as a parse error, making the entire rulebase load silently fail.