### PR TITLE
[ERR-3] Add NULL guard in ln_sampChkRunawayRule for string-mode

### DIFF
--- a/src/samp.c
+++ b/src/samp.c
@@ -946,6 +946,9 @@ ln_sampChkRunawayRule(ln_ctx ctx, FILE *const __restrict__ repo, const char **in
 	int cont = 1;
 	int read;
 
+	if(repo == NULL)
+		return 0; /* nothing to check in string-mode */
+
 	fgetpos(repo, &fpos);
 	while(cont) {
 		fpos_t inner_fpos;


### PR DESCRIPTION
Fixes #19

When `ln_loadSamplesFromString` is used, the `repo` FILE pointer is NULL. The function called `fgetpos(NULL,...)` unconditionally. Added an early return when `repo == NULL` to make the function safe regardless of input source.