### PR TITLE
[TS-1] Document ln_normalize thread safety requirements

### DIFF
--- a/src/liblognorm.h
+++ b/src/liblognorm.h
@@ -254,6 +254,13 @@ int ln_loadSamplesFromString(ln_ctx ctx, const char *string);
  * this means the the correct messages size, \b excluding the NUL byte,
  * must be provided.
  *
+ * @note Thread safety: This function is \b NOT thread-safe when called
+ * concurrently with the same ln_ctx instance. The internal parse-DAG
+ * statistics counters (advstats_* in pdag.c) are updated without any
+ * mutex protection. Either use a separate ln_ctx per thread, or
+ * serialize all ln_normalize() calls on a shared ln_ctx with an
+ * external mutex.
+ *
  * @param[in] ctx The library context to use.
  * @param[in] str The message string (see note above).
  * @param[in] strLen The length of the message in bytes.

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -30,6 +30,10 @@
 void ln_displayPDAGComponentAlternative(struct ln_pdag *dag, int level);
 void ln_displayPDAGComponent(struct ln_pdag *dag, int level);
 
+/* NOTE: These global counters are NOT protected by a mutex.
+ * ln_normalize() must not be called concurrently with the same
+ * ln_ctx instance. Use separate ln_ctx per thread, or serialize
+ * calls with an external mutex. See liblognorm.h for details. */
 #ifdef	ADVANCED_STATS
 uint64_t advstats_parsers_called = 0;
 uint64_t advstats_parsers_success = 0;


### PR DESCRIPTION
Fixes #20

The global `advstats_*` counters in pdag.c are not protected by any mutex. Added a warning comment above the globals and a `@note Thread safety:` paragraph to `ln_normalize`'s doxygen block explaining that concurrent calls on the same context are unsafe.