### PR TITLE
[BS-2] Add LIBXML2_CFLAGS/LIBS from pkg-config in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,8 +42,8 @@ liblognorm_la_SOURCES += \
 	v1_ptree.c \
 	v1_samp.c
 
-liblognorm_la_CPPFLAGS = $(JSON_C_CFLAGS) $(WARN_CFLAGS) $(LIBESTR_CFLAGS) $(PCRE_CFLAGS)
-liblognorm_la_LIBADD = $(rt_libs) $(JSON_C_LIBS) $(LIBESTR_LIBS) $(PCRE_LIBS) -lestr -lxml2
+liblognorm_la_CPPFLAGS = $(JSON_C_CFLAGS) $(WARN_CFLAGS) $(LIBESTR_CFLAGS) $(PCRE_CFLAGS) $(LIBXML2_CFLAGS)
+liblognorm_la_LIBADD = $(rt_libs) $(JSON_C_LIBS) $(LIBESTR_LIBS) $(PCRE_LIBS) $(LIBXML2_LIBS) -lestr
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # Note: v2 now starts at version 5, as v1 previously also had 4


### PR DESCRIPTION
Fixes #21

`src/Makefile.am` was using a hardcoded `-lxml2` and missing `$(LIBXML2_CFLAGS)` in CPPFLAGS. Replaced with the pkg-config variables `$(LIBXML2_CFLAGS)` and `$(LIBXML2_LIBS)` that `configure.ac` already resolves via `PKG_CHECK_MODULES(LIBXML2)`.