### PR TITLE
[BS-3/BS-4] Fix valgrind shell assignment and private header installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_ARG_ENABLE(valgrind,
         [AS_HELP_STRING([--enable-valgrind],[valgrind enabled @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_valgrind="yes" ;;
-          no) enable_valgrind=="no" ;;
+          no) enable_valgrind="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-valgrind) ;;
          esac],
         [enable_valgrind=no]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,4 +67,7 @@ EXTRA_DIST += \
 	v1_samp.h \
 	v1_ptree.h
 
-include_HEADERS = liblognorm.h samp.h lognorm.h pdag.h annot.h enc.h parser.h lognorm-features.h
+include_HEADERS = liblognorm.h lognorm-features.h
+
+noinst_HEADERS = samp.h lognorm.h pdag.h annot.h enc.h parser.h \
+                 internal.h helpers.h

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {


### PR DESCRIPTION
Fixes #22
Fixes #23

**BS-3:** `configure.ac:156` used `==` instead of `=` in the shell assignment for `enable_valgrind`, causing valgrind to always be considered enabled.

**BS-4:** Private internal headers (`internal.h`, `lognorm.h`, `pdag.h`, etc.) were listed in `include_HEADERS` and installed as public API. Moved them to `noinst_HEADERS`.