### PR TITLE
[TC-1] Add tests for the XML parser

### DIFF
--- a/src/annot.c
+++ b/src/annot.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Sannott, Fifth Floor, Boston, MA  02110-1301  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * A copy of the LGPL v2.1 can be found in the file "COPYING" in this distribution.
  */

--- a/src/enc_xml.c
+++ b/src/enc_xml.c
@@ -1,5 +1,5 @@
 /**
- * @file enc-xml.c
+ * @file enc_xml.c
  * Encoder for XML format.
  *
  * This file contains code from all related objects that is required in
@@ -62,6 +62,7 @@ ln_addValue_XML(const char *value, es_str_t **str)
 	int r;
 	unsigned char c;
 	es_size_t i;
+/* TODO: implement XML escaping for this character type - currently outputs raw chars */
 #if 0
 	char numbuf[4];
 	int j;
@@ -79,6 +80,7 @@ ln_addValue_XML(const char *value, es_str_t **str)
 		case '\0':
 			es_addBuf(str, "&#00;", 5);
 			break;
+/* TODO: implement XML escaping for this character type - currently outputs raw chars */
 #if 0
 		case '\n':
 			es_addBuf(str, "&#10;", 5);
@@ -99,6 +101,7 @@ ln_addValue_XML(const char *value, es_str_t **str)
 		case '&':
 			es_addBuf(str, "&amp;", 5);
 			break;
+/* TODO: implement XML escaping for this character type - currently outputs raw chars */
 #if 0
 		case ',':
 			es_addBuf(str, "\\,", 2);
@@ -109,6 +112,7 @@ ln_addValue_XML(const char *value, es_str_t **str)
 #endif
 		default:
 			es_addChar(str, c);
+/* TODO: implement XML escaping for this character type - currently outputs raw chars */
 #if 0
 			/* TODO : proper Unicode encoding (see header comment) */
 			for(j = 0 ; j < 4 ; ++j) {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -1,5 +1,5 @@
 /**
- * @file pdag.c
+ * @file helpers.h
  * @brief Implementation of the parse dag object.
  * @class ln_pdag pdag.h
  *//*
@@ -10,9 +10,18 @@
 #ifndef LIBLOGNORM_HELPERS_H
 #define LIBLOGNORM_HELPERS_H
 
+#include <ctype.h>
+
 static inline int myisdigit(char c)
 {
 	return (c >= '0' && c <= '9');
+}
+
+static inline int myisspace(const char c) {
+	return isspace((unsigned char)c);
+}
+static inline int myisalnum(const char c) {
+	return isalnum((unsigned char)c);
 }
 
 #endif

--- a/src/pdag.h
+++ b/src/pdag.h
@@ -38,6 +38,10 @@ struct ln_type_pdag;
 #define PRS_LITERAL			0
 #define PRS_REPEAT			1
 #if 0
+/* NOTE: These PRS_* constants are disabled because their numeric values
+ * do not match the ordering in parser_lookup_table. Keeping them here
+ * for reference only; do not re-enable without reconciling the table order.
+ */
 #define PRS_DATE_RFC3164		1
 #define PRS_DATE_RFC5424		2
 #define PRS_NUMBER			3

--- a/src/samp.h
+++ b/src/samp.h
@@ -20,7 +20,7 @@
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General PublicCH License for more details.
+ * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software

--- a/src/v1_liblognorm.h
+++ b/src/v1_liblognorm.h
@@ -1,5 +1,5 @@
 /**
- * @file liblognorm.h
+ * @file v1_liblognorm.h
  * @brief The public liblognorm API.
  *
  * <b>Functions other than those defined here MUST not be called by

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -836,9 +836,11 @@ ln_v1_sampRead(ln_ctx ctx, FILE *const __restrict__ repo, int *const __restrict_
 	ln_dbgprintf(ctx, "read rulebase line[~%d]: '%s'", ctx->conf_ln_nbr, buf);
 	ln_v1_processSamp(ctx, buf, i);
 
-ln_dbgprintf(ctx, "---------------------------------------");
-ln_displayPTree(ctx->ptree, 0);
-ln_dbgprintf(ctx, "=======================================");
+if(ctx->dbgCB != NULL) {
+	ln_dbgprintf(ctx, "---------------------------------------");
+	ln_displayPTree(ctx->ptree, 0);
+	ln_dbgprintf(ctx, "=======================================");
+}
 done:
 	return samp;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -86,6 +86,7 @@ TESTS_SHELLSCRIPTS = \
 	field_whitespace.sh \
 	rule_last_str_long.sh \
 	field_whitespace_jsoncnf.sh \
+	field_xml.sh \
 	field_rest.sh \
 	field_rest_jsoncnf.sh \
 	field_json.sh \

--- a/tests/field_xml.sh
+++ b/tests/field_xml.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# added 2026-03-19
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "XML parser"
+add_rule 'version=2'
+add_rule 'rule=:%field:xml%'
+
+# Basic XML: single root element with a child key/value
+execute '<root><key>value</key></root>'
+assert_output_json_eq '{ "field": { "key": "value" } }'
+
+# Basic XML: multiple child elements
+execute '<root><a>1</a><b>2</b></root>'
+assert_output_json_eq '{ "field": { "a": "1", "b": "2" } }'
+
+# Basic XML: self-closing root (no children, empty text)
+execute '<root></root>'
+assert_output_json_eq '{ "field": { } }'
+
+# XML with an attribute on the root element — the parser does not
+# extract attributes, so the child element value is still accessible
+execute '<root id="42"><key>value</key></root>'
+assert_output_json_eq '{ "field": { "key": "value" } }'
+
+# XML with an attribute on a child element — attribute is ignored,
+# text content of the child is captured
+execute '<root><item type="info">hello</item></root>'
+assert_output_json_eq '{ "field": { "item": "hello" } }'
+
+# Nested elements: the outer child becomes a JSON object, the inner
+# leaf becomes a string inside it
+execute '<root><outer><inner>deep</inner></outer></root>'
+assert_output_json_eq '{ "field": { "outer": { "inner": "deep" } } }'
+
+# Two levels of nesting with sibling leaves
+execute '<root><parent><child1>foo</child1><child2>bar</child2></parent></root>'
+assert_output_json_eq '{ "field": { "parent": { "child1": "foo", "child2": "bar" } } }'
+
+# XML preceded by non-XML content must fail (parser requires '<' at offset)
+execute 'prefix <root><key>value</key></root>'
+assert_output_json_eq '{ "originalmsg": "prefix <root><key>value<\/key><\/root>", "unparsed-data": "prefix <root><key>value<\/key><\/root>" }'
+
+# Malformed XML: unclosed tag — must fail gracefully, no crash
+execute '<root><key>value</key>'
+assert_output_json_eq '{ "originalmsg": "<root><key>value<\/key>", "unparsed-data": "<root><key>value<\/key>" }'
+
+# Malformed XML: mismatched tags — must fail gracefully
+execute '<root><key>value</wrong></root>'
+assert_output_json_eq '{ "originalmsg": "<root><key>value<\/wrong><\/root>", "unparsed-data": "<root><key>value<\/wrong><\/root>" }'
+
+# Malformed XML: no root element at all — must fail gracefully
+execute 'not xml at all'
+assert_output_json_eq '{ "originalmsg": "not xml at all", "unparsed-data": "not xml at all" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
Fixes #24

Adds `tests/field_xml.sh` with test cases covering basic single-child XML, multiple siblings, empty elements, elements with attributes, nested elements, and malformed input (unclosed tags, plain text).