### PR TITLE
[TC-4] Add edge case tests for op-quoted-string parser

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/tests/field_op-quoted-string.sh
+++ b/tests/field_op-quoted-string.sh
@@ -48,5 +48,32 @@ assert_output_json_eq '{ "test2": "ijkl\\\"mnop", "test": "abcd\"efgh\\" }'
 execute '"abcd\"efgh" "ijkl'
 assert_output_json_eq '{ "originalmsg": "\"abcd\\\"efgh\" \"ijkl", "unparsed-data": "\"ijkl" }'
 
+# Edge case: empty quoted string
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%test:op-quoted-string%'
+execute '""'
+assert_output_json_eq '{ "test": "" }'
+
+# Edge case: consecutive escape sequences "a\\\\b" — two real backslashes
+# The shell passes "a\\b" (each \\ becomes one \), so the parser sees a\\b
+execute '"a\\\\b"'
+assert_output_json_eq '{ "test": "a\\\\b" }'
+
+# Edge case: unicode inside quoted string
+execute '"café"'
+assert_output_json_eq '{ "test": "café" }'
+
+# Edge case: long quoted string (well above typical buffer boundaries)
+execute '"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"'
+assert_output_json_eq '{ "test": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" }'
+
+# Edge case: quoted string followed by space and rest parser
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%test:op-quoted-string% %tail:rest%'
+execute '"hello world" and more text'
+assert_output_json_eq '{ "test": "hello world", "tail": "and more text" }'
+
 cleanup_tmp_files
 


### PR DESCRIPTION
Fixes #27

Adds tests for empty quoted string, consecutive escape sequences, unicode characters inside quotes, and long strings to the existing `field_op-quoted-string.sh`.