### PR TITLE
[TC-5] Add tests for word, alpha, string-to, and quoted-string parsers

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -108,7 +108,11 @@ TESTS_SHELLSCRIPTS = \
 	field_float_jsoncnf.sh \
 	field_rfc5424timestamp-fmt_timestamp-unix.sh \
 	field_rfc5424timestamp-fmt_timestamp-unix-ms.sh \
-	very_long_logline_jsoncnf.sh
+	very_long_logline_jsoncnf.sh \
+	field_word.sh \
+	field_alpha.sh \
+	field_string-to.sh \
+	field_quoted-string.sh
 
 # now come tests for the legacy (v1) engine
 TESTS_SHELLSCRIPTS += \

--- a/tests/field_alpha.sh
+++ b/tests/field_alpha.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Tests for the "alpha" parser (matches a sequence of alpha-only chars)
+# added 2026-03-19 (TC-5)
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "alpha parser"
+
+add_rule 'version=2'
+add_rule 'rule=:action=%action:alpha% code=%code:number%'
+
+execute 'action=login code=42'
+assert_output_json_eq '{ "action": "login", "code": "42" }'
+
+execute 'action=LOGOUT code=0'
+assert_output_json_eq '{ "action": "LOGOUT", "code": "0" }'
+
+# mismatch: digits in alpha field
+execute 'action=log1n code=5'
+assert_output_json_eq '{ "originalmsg": "action=log1n code=5", "unparsed-data": "action=log1n code=5" }'
+
+cleanup_tmp_files

--- a/tests/field_quoted-string.sh
+++ b/tests/field_quoted-string.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Tests for the "quoted-string" parser (matches a double-quoted string)
+# added 2026-03-19 (TC-5)
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "quoted-string parser"
+
+add_rule 'version=2'
+add_rule 'rule=:msg=%msg:quoted-string%'
+
+execute 'msg="hello world"'
+assert_output_json_eq '{ "msg": "hello world" }'
+
+execute 'msg="with \"escaped\" quotes"'
+assert_output_json_eq '{ "msg": "with \"escaped\" quotes" }'
+
+# empty quoted string
+execute 'msg=""'
+assert_output_json_eq '{ "msg": "" }'
+
+# mismatch: no opening quote
+execute 'msg=hello world'
+assert_output_json_eq '{ "originalmsg": "msg=hello world", "unparsed-data": "msg=hello world" }'
+
+cleanup_tmp_files

--- a/tests/field_string-to.sh
+++ b/tests/field_string-to.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Tests for the "string-to" parser (matches everything up to a given substring)
+# added 2026-03-19 (TC-5)
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "string-to parser"
+
+add_rule 'version=2'
+add_rule 'rule=:src=%src:string-to:->% -> %dst:string-to: %'
+
+execute 'src=1.2.3.4 -> dst=5.6.7.8'
+assert_output_json_eq '{ "src": "src=1.2.3.4 ", "dst": "dst=5.6.7.8" }'
+
+# no match: terminator not found
+execute 'src=1.2.3.4 without arrow'
+assert_output_json_eq '{ "originalmsg": "src=1.2.3.4 without arrow", "unparsed-data": "src=1.2.3.4 without arrow" }'
+
+cleanup_tmp_files

--- a/tests/field_word.sh
+++ b/tests/field_word.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Tests for the "word" parser (matches a sequence of non-whitespace chars)
+# added 2026-03-19 (TC-5)
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "word parser"
+
+add_rule 'version=2'
+add_rule 'rule=:action=%action:word% user=%user:word%'
+
+execute 'action=login user=alice'
+assert_output_json_eq '{ "action": "login", "user": "alice" }'
+
+execute 'action=LOGOUT user=bob123'
+assert_output_json_eq '{ "action": "LOGOUT", "user": "bob123" }'
+
+# mismatch: second word missing
+execute 'action=login user='
+assert_output_json_eq '{ "originalmsg": "action=login user=", "unparsed-data": "action=login user=" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
Fixes #28

Adds four new test files (`field_word.sh`, `field_alpha.sh`, `field_string-to.sh`, `field_quoted-string.sh`) providing baseline happy-path and mismatch tests for parsers that had no dedicated test coverage.