### PR TITLE
[TC-6] Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    name: Build and Test (gcc)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            libtool \
+            pkg-config \
+            libjson-c-dev \
+            libfastjson-dev \
+            libestr-dev \
+            libxml2-dev \
+            valgrind \
+            clang
+
+      - name: Bootstrap build system
+        run: autoreconf -fi
+
+      - name: Configure
+        run: ./configure --enable-testbench
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Run tests
+        run: make check
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-gcc
+          path: |
+            tests/*.log
+            tests/testsuite.log
+
+  asan-ubsan:
+    name: Build and Test (clang ASan/UBSan)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            libtool \
+            pkg-config \
+            libjson-c-dev \
+            libfastjson-dev \
+            libestr-dev \
+            libxml2-dev \
+            clang
+
+      - name: Bootstrap build system
+        run: autoreconf -fi
+
+      - name: Configure with ASan/UBSan
+        env:
+          CC: clang
+          CFLAGS: "-fsanitize=address,undefined -g -O1"
+          LDFLAGS: "-fsanitize=address,undefined"
+        run: ./configure --enable-testbench
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: "abort_on_error=1:detect_leaks=1"
+          UBSAN_OPTIONS: "abort_on_error=1:print_stacktrace=1"
+        run: make check
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-asan
+          path: |
+            tests/*.log
+            tests/testsuite.log

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {


### PR DESCRIPTION
Fixes #29

Adds `.github/workflows/ci.yml` with two jobs: a standard `make check` build on GCC, and an AddressSanitizer + UBSan build on Clang that will catch the class of bugs identified in the security review.