### PR TITLE
[TC-7] Remove duplicate test entry and dead user_test comment

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -129,7 +129,6 @@ TESTS_SHELLSCRIPTS += \
 	field_checkpoint-lea_v1.sh \
 	field_duration_v1.sh \
 	field_float_v1.sh \
-	field_cee-syslog_v1.sh \
 	field_tokenized.sh \
 	field_tokenized_with_invalid_ruledef.sh \
 	field_recursive.sh \
@@ -146,7 +145,6 @@ TESTS_SHELLSCRIPTS += \
 	very_long_logline.sh
 
 
-#re-add to TESTS if needed: user_test
 TESTS = \
 	$(TESTS_SHELLSCRIPTS)
 


### PR DESCRIPTION
Fixes #30

`field_cee-syslog_v1.sh` was listed twice in `TESTS_SHELLSCRIPTS`, causing automake to warn and the test to run twice. Also removed the stale `#re-add to TESTS if needed: user_test` comment.