### PR TITLE
[TD-1] Implement ln_annot_RM annotation removal

### DIFF
--- a/src/annot.c
+++ b/src/annot.c
@@ -202,8 +202,9 @@ ln_annotateEventWithTag(ln_ctx ctx, struct json_object *json, es_str_t *tag)
 			CHKN(field = json_object_new_string(cstr));
 			CHKN(cstr = ln_es_str2cstr(&op->name));
 			json_object_object_add(json, cstr, field);
-		} else {
-			// TODO: implement
+		} else if(op->opc == ln_annot_RM) {
+			CHKN(cstr = ln_es_str2cstr(&op->name));
+			json_object_object_del(json, cstr);
 		}
 	}
 

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/src/samp.c
+++ b/src/samp.c
@@ -749,8 +749,8 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 		r = 0;
 		goto done;
 	case '-':
-		ln_dbgprintf(ctx, "annotate op '-' not yet implemented - failing");
-		/*FALLTHROUGH*/
+		opc = ln_annot_RM;
+		break;
 	default:ln_errprintf(ctx, 0, "invalid annotate operation '%c': %s", buf[i], buf+i);
 		goto fail;
 	}
@@ -759,6 +759,15 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 	if(i == lenBuf) goto fail; /* nothing left to process */
 
 	CHKR(getFieldName(ctx, buf, lenBuf, &i, &fieldName));
+
+	if(opc == ln_annot_RM) {
+		/* RM operations only have a field name, no =value part */
+		*offs = i;
+		CHKR(ln_addAnnotOp(annot, opc, fieldName, NULL));
+		r = 0;
+		goto done;
+	}
+
 	if(i == lenBuf) goto fail; /* nothing left to process */
 	if(buf[i] != '=') goto fail; /* format error */
 	i++;

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -683,8 +683,7 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 	if(buf[i] == '+') {
 		opc = ln_annot_ADD;
 	} else if(buf[i] == '-') {
-		ln_dbgprintf(ctx, "annotate op '-' not yet implemented - failing");
-		goto fail;
+		opc = ln_annot_RM;
 	} else {
 		ln_dbgprintf(ctx, "invalid annotate opcode '%c' - failing" , buf[i]);
 		goto fail;
@@ -694,6 +693,15 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 	if(i == lenBuf) goto fail; /* nothing left to process */
 
 	CHKR(getFieldName(ctx, buf, lenBuf, &i, &fieldName));
+
+	if(opc == ln_annot_RM) {
+		/* RM operations only have a field name, no =value part */
+		*offs = i;
+		CHKR(ln_addAnnotOp(annot, opc, fieldName, NULL));
+		r = 0;
+		goto done;
+	}
+
 	if(i == lenBuf) goto fail; /* nothing left to process */
 	if(buf[i] != '=') goto fail; /* format error */
 	i++;

--- a/tests/annotate.sh
+++ b/tests/annotate.sh
@@ -21,4 +21,14 @@ assert_output_json_eq '{ "tag": "TAG", "annot2": "ABC" }'
 execute '<6>1 2016-09-02T07:41:07+02:00 server.example.net TAG - - -'
 assert_output_json_eq '{ "tag": "TAG", "annot1": "WIN", "annot2": "ABC" }'
 
+# Test RM operation: annotate with '-' removes a previously added field
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=RMTEST:<%-:number%>1 %-:date-rfc5424% %-:word% %tag:word% - - -'
+add_rule 'annotate=RMTEST:+annot1="to-be-removed" +annot2="keep-me"'
+add_rule 'annotate=RMTEST:-annot1'
+
+execute '<6>1 2016-09-02T07:41:07+02:00 server.example.net TAG - - -'
+assert_output_json_eq '{ "tag": "TAG", "annot2": "keep-me" }'
+
 cleanup_tmp_files


### PR DESCRIPTION
Fixes #31

`ln_annot_RM` was declared in the public API but never implemented. Adds support for the `-` annotation opcode which removes tags from normalized events, completing the annotation API.