### PR TITLE
[TD-2] Fix ln_v1_processSamp: change return type from ptr to int

### DIFF
--- a/src/v1_liblognorm.c
+++ b/src/v1_liblognorm.c
@@ -63,8 +63,7 @@ ln_v1_inherittedCtx(ln_ctx parent)
 int
 ln_v1_loadSample(ln_ctx ctx, const char *buf)
 {
-	// Something bad happened - no new sample
-	if (ln_v1_processSamp(ctx, buf, strlen(buf)) == NULL) {
+	if (ln_v1_processSamp(ctx, buf, strlen(buf)) != 0) {
 		return 1;
 	}
 	return 0;

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -755,10 +755,10 @@ processAnnotate(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t offs)
 done:	return r;
 }
 
-struct ln_v1_samp *
+int
 ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 {
-	struct ln_v1_samp *samp = NULL;
+	int r = -1;
 	es_str_t *typeStr = NULL;
 	es_size_t offs;
 
@@ -774,19 +774,19 @@ ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 	} else if(!es_strconstcmp(typeStr, "annotate")) {
 		if(processAnnotate(ctx, buf, lenBuf, offs) != 0) goto done;
 	} else {
-		/* TODO error reporting */
 		char *str;
 		str = es_str2cstr(typeStr, NULL);
-		ln_dbgprintf(ctx, "invalid record type detected: '%s'", str);
+		ln_errprintf(ctx, 0, "invalid record type detected: '%s'", str);
 		free(str);
 		goto done;
 	}
+	r = 0;
 
 done:
 	if(typeStr != NULL)
 		es_deleteStr(typeStr);
 
-	return samp;
+	return r;
 }
 
 

--- a/src/v1_samp.h
+++ b/src/v1_samp.h
@@ -42,19 +42,14 @@ struct ln_v1_samp {
 };
 
 /**
- * Reads a sample stored in buffer buf and creates a new ln_v1_samp object
- * out of it.
+ * Process a sample stored in buffer buf and add it to the v1 parse tree.
  *
- * @note
- * It is the caller's responsibility to delete the newly
- * created ln_v1_samp object if it is no longer needed.
- *
- * @param[ctx] ctx current library context
- * @param[buf] cstr buffer containing the string contents of the sample
- * @param[lenBuf] length of the sample contained within buf
- * @return Newly create object or NULL if an error occured.
+ * @param[in] ctx current library context
+ * @param[in] buf cstr buffer containing the string contents of the sample
+ * @param[in] lenBuf length of the sample contained within buf
+ * @return 0 on success, non-zero on error.
  */
-struct ln_v1_samp *
+int
 ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf);
 
 


### PR DESCRIPTION
Fixes #32

The function declared `struct ln_v1_samp *` as return type but `samp` was always NULL, so every caller checking for NULL received a false failure indication. Changed return type to `int` (0 = success), updated the header and fixed the caller in `v1_liblognorm.c`.