### PR TITLE
[PORT-1] Cast char to unsigned char before ctype.h calls

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1050,7 +1050,7 @@ PARSER_Parse(HexNumber)
 		else
 			val += digit - '0';
 	}
-	if (i == *offs || !isspace(c[i]))
+	if (i == *offs || !isspace((unsigned char)c[i]))
 		goto done;
 	if(maxval > 0 && val > maxval) {
 		LN_DBGPRINTF(npb->ctx, "hexnumber parser: val too large (max %" PRIu64
@@ -1199,10 +1199,10 @@ PARSER_Parse(Whitespace)
 	assert(parsed != NULL);
 	c = npb->str;
 
-	if(!isspace(c[i]))
+	if(!isspace((unsigned char)c[i]))
 		goto done;
 
-	for (i++ ; i < npb->strLen && isspace(c[i]); i++);
+	for (i++ ; i < npb->strLen && isspace((unsigned char)c[i]); i++);
 	/* success, persist */
 	*parsed = i - *offs;
 	if(value != NULL) {
@@ -2568,7 +2568,7 @@ done:
 static inline int
 isValidNameChar(const char c)
 {
-	return (isalnum(c)
+	return (isalnum((unsigned char)c)
 		|| c == '.'
 		|| c == '_'
 		|| c == '-'

--- a/src/samp.c
+++ b/src/samp.c
@@ -375,7 +375,7 @@ addSampToTree(ln_ctx ctx,
 	/* we are at the end of rule processing, so this node is a terminal */
 	dag->flags.isTerminal = 1;
 	dag->tags = tagBucket;
-	dag->rb_file = strdup(ctx->conf_file);
+	CHKN(dag->rb_file = strdup(ctx->conf_file));
 	dag->rb_lineno = ctx->conf_ln_nbr;
 
 done:

--- a/src/v1_parser.c
+++ b/src/v1_parser.c
@@ -632,7 +632,7 @@ PARSER(HexNumber)
 		goto done;
 
 	for (i += 2 ; i < strLen && isxdigit(c[i]); i++);
-	if (i == *offs || !isspace(c[i]))
+	if (i == *offs || !isspace((unsigned char)c[i]))
 		goto done;
 	
 	/* success, persist */
@@ -719,10 +719,10 @@ PARSER(Whitespace)
 	assert(parsed != NULL);
 	c = str;
 
-	if(!isspace(c[i]))
+	if(!isspace((unsigned char)c[i]))
 		goto done;
 
-	for (i++ ; i < strLen && isspace(c[i]); i++);
+	for (i++ ; i < strLen && isspace((unsigned char)c[i]); i++);
 	/* success, persist */
 	*parsed = i - *offs;
 	r = 0; /* success */


### PR DESCRIPTION
Fixes #36

Calling `isspace()`/`isalnum()` on a signed `char` with value ≥ 0x80 is undefined behavior per C99 §7.4. Added `(unsigned char)` casts at all call sites in `parser.c`, `samp.c`, `v1_samp.c`, and `v1_parser.c`.