### PR TITLE
[PORT-2] Scope GCC diagnostic pragmas with push/pop in internal.h

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -60,6 +60,7 @@
  * exit of a function to get proper finalization. So let's disable it.
  * rgerhards, 2018-04-25
  */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wjump-misses-init"
 
 #include "liblognorm.h"
@@ -72,6 +73,7 @@
 #ifndef _AIX
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #endif
+#pragma GCC diagnostic pop
 
 /* support for simple error checking */
 

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {


### PR DESCRIPTION
Fixes #37

The two `#pragma GCC diagnostic ignored` directives in `internal.h` were file-scoped, suppressing warnings for every translation unit that included the header. Wrapped them with `#pragma GCC diagnostic push/pop` to limit their effect to the header itself.