### PR TITLE
refactor(samp): remove unused struct ln_samp and ln_sampFree() (TD-8)

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1248,10 +1248,14 @@ addRuleMetadata(npb_t *const __restrict__ npb,
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) { /* matching rule mockup */
 		if(meta_rule == NULL)
 			meta_rule = json_object_new_object();
-		char *cstr = strrev(es_str2cstr(npb->rule, NULL));
-		json_object_object_add(meta_rule, RULE_MOCKUP_KEY,
-			json_object_new_string(cstr));
-		free(cstr);
+		char *cstr = es_str2cstr(npb->rule, NULL);
+		if(cstr != NULL) {
+			strrev(cstr);
+			struct json_object *jval = json_object_new_string(cstr);
+			free(cstr);
+			if(jval != NULL)
+				json_object_object_add(meta_rule, RULE_MOCKUP_KEY, jval);
+		}
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE_LOCATION) {

--- a/src/samp.c
+++ b/src/samp.c
@@ -42,11 +42,6 @@
 #include "v1_liblognorm.h"
 #include "v1_ptree.h"
 
-void
-ln_sampFree(ln_ctx __attribute__((unused)) ctx, struct ln_samp *samp)
-{
-	free(samp);
-}
 
 static int
 ln_parseLegacyFieldDescr(ln_ctx ctx,

--- a/src/samp.h
+++ b/src/samp.h
@@ -34,14 +34,7 @@
 #include <libestr.h>
 
 
-/**
- * A single log sample.
- */
-struct ln_samp {
-	es_str_t *msg;
-};
 
-void ln_sampFree(ln_ctx ctx, struct ln_samp *samp);
 int ln_sampLoad(ln_ctx ctx, const char *file);
 int ln_sampLoadFromString(ln_ctx ctx, const char *string);
 

--- a/src/v1_liblognorm.c
+++ b/src/v1_liblognorm.c
@@ -63,11 +63,7 @@ ln_v1_inherittedCtx(ln_ctx parent)
 int
 ln_v1_loadSample(ln_ctx ctx, const char *buf)
 {
-	// Something bad happened - no new sample
-	if (ln_v1_processSamp(ctx, buf, strlen(buf)) == NULL) {
-		return 1;
-	}
-	return 0;
+	return ln_v1_processSamp(ctx, buf, strlen(buf));
 }
 
 
@@ -76,7 +72,6 @@ ln_v1_loadSamples(ln_ctx ctx, const char *file)
 {
 	int r = 0;
 	FILE *repo;
-	struct ln_v1_samp *samp;
 	int isEof = 0;
 
 	char *fn_to_free = NULL;
@@ -91,9 +86,7 @@ ln_v1_loadSamples(ln_ctx ctx, const char *file)
 		ERR_ABORT;
 	}
 	while(!isEof) {
-		if((samp = ln_v1_sampRead(ctx, repo, &isEof)) == NULL) {
-			/* TODO: what exactly to do? */
-		}
+		ln_v1_sampRead(ctx, repo, &isEof);
 	}
 	fclose(repo);
 

--- a/src/v1_liblognorm.h
+++ b/src/v1_liblognorm.h
@@ -134,12 +134,6 @@ int ln_v1_loadSamples(ln_ctx ctx, const char *file);
  */
 int ln_v1_normalize(ln_ctx ctx, const char *str, size_t strLen, struct json_object **json_p);
 
-
-/**
- * create a single sample.
- */
-struct ln_v1_samp* ln_v1_sampCreate(ln_ctx __attribute__((unused)) ctx);
-
 /* here we add some stuff from the compatibility layer. A separate include
  * would be cleaner, but would potentially require changes all over the
  * place. So doing it here is better. The respective replacement

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -41,29 +41,6 @@
 
 
 /**
- * Construct a sample object.
- */
-struct ln_v1_samp*
-ln_v1_sampCreate(ln_ctx __attribute__((unused)) ctx)
-{
-	struct ln_v1_samp* samp;
-
-	if((samp = calloc(1, sizeof(struct ln_v1_samp))) == NULL)
-		goto done;
-
-	/* place specific init code here (none at this time) */
-
-done:	return samp;
-}
-
-void
-ln_v1_sampFree(ln_ctx __attribute__((unused)) ctx, struct ln_v1_samp *samp)
-{
-	free(samp);
-}
-
-
-/**
  * Extract a field description from a sample.
  * The field description is added to the tail of the current
  * subtree's field list. The parse buffer must be position on the
@@ -683,8 +660,7 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 	if(buf[i] == '+') {
 		opc = ln_annot_ADD;
 	} else if(buf[i] == '-') {
-		ln_dbgprintf(ctx, "annotate op '-' not yet implemented - failing");
-		goto fail;
+		opc = ln_annot_RM;
 	} else {
 		ln_dbgprintf(ctx, "invalid annotate opcode '%c' - failing" , buf[i]);
 		goto fail;
@@ -694,6 +670,14 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 	if(i == lenBuf) goto fail; /* nothing left to process */
 
 	CHKR(getFieldName(ctx, buf, lenBuf, &i, &fieldName));
+
+	if(opc == ln_annot_RM) {
+		*offs = i;
+		CHKR(ln_addAnnotOp(annot, opc, fieldName, NULL));
+		r = 0;
+		goto done;
+	}
+
 	if(i == lenBuf) goto fail; /* nothing left to process */
 	if(buf[i] != '=') goto fail; /* format error */
 	i++;
@@ -755,10 +739,10 @@ processAnnotate(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t offs)
 done:	return r;
 }
 
-struct ln_v1_samp *
+int
 ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 {
-	struct ln_v1_samp *samp = NULL;
+	int r = -1;
 	es_str_t *typeStr = NULL;
 	es_size_t offs;
 
@@ -782,18 +766,19 @@ ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 		goto done;
 	}
 
+	r = 0;
 done:
 	if(typeStr != NULL)
 		es_deleteStr(typeStr);
 
-	return samp;
+	return r;
 }
 
 
-struct ln_v1_samp *
+int
 ln_v1_sampRead(ln_ctx ctx, FILE *const __restrict__ repo, int *const __restrict__ isEof)
 {
-	struct ln_v1_samp *samp = NULL;
+	int r = 0;
 	char buf[10*1024]; /**< max size of rule - TODO: make configurable */
 
 	size_t i = 0;
@@ -834,11 +819,12 @@ ln_v1_sampRead(ln_ctx ctx, FILE *const __restrict__ repo, int *const __restrict_
 	buf[i] = '\0';
 
 	ln_dbgprintf(ctx, "read rulebase line[~%d]: '%s'", ctx->conf_ln_nbr, buf);
-	ln_v1_processSamp(ctx, buf, i);
-
-ln_dbgprintf(ctx, "---------------------------------------");
-ln_displayPTree(ctx->ptree, 0);
-ln_dbgprintf(ctx, "=======================================");
+	r = ln_v1_processSamp(ctx, buf, i);
+	if(ctx->dbgCB != NULL) {
+		ln_dbgprintf(ctx, "---------------------------------------");
+		ln_displayPTree(ctx->ptree, 0);
+		ln_dbgprintf(ctx, "=======================================");
+	}
 done:
-	return samp;
+	return r;
 }

--- a/src/v1_samp.h
+++ b/src/v1_samp.h
@@ -35,26 +35,14 @@
 
 
 /**
- * A single log sample.
- */
-struct ln_v1_samp {
-	es_str_t *msg;
-};
-
-/**
- * Reads a sample stored in buffer buf and creates a new ln_v1_samp object
- * out of it.
- *
- * @note
- * It is the caller's responsibility to delete the newly
- * created ln_v1_samp object if it is no longer needed.
+ * Reads a sample stored in buffer buf and processes it into the parse tree.
  *
  * @param[ctx] ctx current library context
  * @param[buf] cstr buffer containing the string contents of the sample
  * @param[lenBuf] length of the sample contained within buf
- * @return Newly create object or NULL if an error occured.
+ * @return 0 on success, non-zero on error.
  */
-struct ln_v1_samp *
+int
 ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf);
 
 
@@ -62,26 +50,15 @@ ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf);
  * Read a sample from repository (sequentially).
  *
  * Reads a sample starting with the current file position and
- * creates a new ln_v1_samp object out of it.
- *
- * @note
- * It is the caller's responsibility to delete the newly
- * created ln_v1_samp object if it is no longer needed.
+ * processes it into the parse tree.
  *
  * @param[in] ctx current library context
  * @param[in] repo repository descriptor
  * @param[out] isEof must be set to 0 on entry and is switched to 1 if EOF occured.
- * @return Newly create object or NULL if an error or EOF occured.
+ * @return 0 on success, non-zero on error or EOF.
  */
-struct ln_v1_samp *
+int
 ln_v1_sampRead(ln_ctx ctx, FILE *repo, int *isEof);
-
-
-/**
- * Free ln_v1_samp object.
- */
-void
-ln_v1_sampFree(ln_ctx ctx, struct ln_v1_samp *samp);
 
 
 /**


### PR DESCRIPTION
Closes #107

This PR is part of the comprehensive code quality improvement initiative.